### PR TITLE
Linux compilation fixes.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ AR?=ar
 LAC_CPPFLAGS= -I./include
 LAC_CFLAGS= -std=gnu99 -Wall -Werror -Wno-unused -O3 -g 
 LAC_LDFLAGS= 
-LAC_LIBS= 
+LAC_LIBS= -lm
 
 LIB_C_FILES= $(wildcard src/*.c)
 LIB_OBJ_FILES= $(addprefix obj/,$(notdir $(LIB_C_FILES:%.c=%.o)))

--- a/include/Prelude+.h
+++ b/include/Prelude+.h
@@ -5,7 +5,7 @@
 #include <stdlib.h>
 #include <stdarg.h>
 #include <stdbool.h>
-
+#include <stdint.h>
 
 /*
 ** == Syntax ==

--- a/tests/functional.c
+++ b/tests/functional.c
@@ -344,7 +344,7 @@ PT_SUITE(suite_functional) {
   PT_TEST(test_new_filter) {
     
     lambda(only_some, args) {
-      return (var)(at(args,0) is Some);
+      return (var)(intptr_t)(at(args,0) is Some);
     }
     
     var values = new(List, 3, Some, Some, None);


### PR DESCRIPTION
Some fixes to get compiled on Ubuntu 12.04 (gcc 4.6.3). There is no problem to build library with clang 3.0.
