### PR TITLE
Add -fnested-functions to tests_CFLAGS

### DIFF
--- a/tests/Makefile.am
+++ b/tests/Makefile.am
@@ -11,7 +11,7 @@ tests_SOURCES = \
   test.c
   
 tests_CPPFLAGS = -I$(top_srcdir)/tests
-tests_CFLAGS = -std=gnu99 -Wall -Werror -Wextra -Wno-unused 
+tests_CFLAGS = -std=gnu99 -Wall -Werror -Wextra -Wno-unused -fnested-functions
 tests_LDFLAGS = -lCello
 
 TESTS = tests


### PR DESCRIPTION
On some versions of GCC (e.g., Xcode's GCC on OS X), the -fnested-functions
flag needs to be passed as nested functions are disabled by default.

This fixes test compilation errors on OS X when using GCC 4.2.1.

Signed-off-by: Eddie Ringle eddie@eringle.net
