### PR TITLE
Thread-safe exceptions

### DIFF
--- a/include/Exception.h
+++ b/include/Exception.h
@@ -38,9 +38,9 @@ enum {
   __EXC_MAX_DEPTH = 2048,
 };
 
-extern bool __exc_active;
-extern int __exc_depth;
-extern jmp_buf __exc_buffers[__EXC_MAX_DEPTH];
+extern __thread bool __exc_active;
+extern __thread int __exc_depth;
+extern __thread jmp_buf __exc_buffers[__EXC_MAX_DEPTH];
 
 var __exc_throw(var obj, const char* fmt, const char* file, const char* func, int lineno, ...);
 var __exc_catch(void* unused, ...);

--- a/src/Exception.c
+++ b/src/Exception.c
@@ -44,9 +44,9 @@ void Exception_Register_Signals(void) {
   signal(SIGTERM, Exception_Signal);
 }
 
-bool __exc_active = false;
-int __exc_depth = -1;
-jmp_buf __exc_buffers[__EXC_MAX_DEPTH];
+__thread bool __exc_active = false;
+__thread int __exc_depth = -1;
+__thread jmp_buf __exc_buffers[__EXC_MAX_DEPTH];
 
 local var __exc_obj = NULL;
 local bool __exc_msg_hook = false;


### PR DESCRIPTION
Fixes #35.

Note that this uses GNU's [thread-local storage extension](http://gcc.gnu.org/onlinedocs/gcc-4.8.1/gcc/Thread_002dLocal.html).
