### PR TITLE
README.md: fix syntax error in the first example

### DIFF
--- a/README
+++ b/README
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
   }
   
   /* "with" automatically closes file at end of scope. */
-  with(file in open($(File, NULL), "prices.bin", "wb"))) {
+  with(file in open($(File, NULL), "prices.bin", "wb")) {
   
     /* First class function object */
     lambda(write_pair, args) {

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ int main(int argc, char** argv) {
   }
   
   /* "with" automatically closes file at end of scope. */
-  with(file in open($(File, NULL), "prices.bin", "wb"))) {
+  with(file in open($(File, NULL), "prices.bin", "wb")) {
   
     /* First class function object */
     lambda(write_pair, args) {


### PR DESCRIPTION
Too many ")" at the end of the line:
  with(file in open($(File, NULL), "prices.bin", "wb"))) {
