### PR TITLE
Fixed OS check in Thread.* to properly check for __APPLE__ environment.

### DIFF
--- a/include/Cello/Thread.h
+++ b/include/Cello/Thread.h
@@ -6,7 +6,7 @@
 #ifndef CelloThread_h
 #define CelloThread_h
 
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   #include <pthread.h>
 #elif defined(_WIN32)
   #undef data
@@ -49,7 +49,7 @@ data {
   var func;
   var args;
   
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   pthread_t thread;
 #elif defined(_WIN32)
   HANDLE thread;
@@ -119,7 +119,7 @@ global var Mutex;
  
 data {
   var type;
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   pthread_mutex_t mutex;
 #elif defined(_WIN32)
   HANDLE mutex;

--- a/src/Thread.c
+++ b/src/Thread.c
@@ -113,7 +113,7 @@ long Thread_Hash(var self) {
 long Thread_AsLong(var self) {
   ThreadData* td = cast(self, Thread);
   if (not td->running) { throw(ValueError, "Cannot get thread ID, thread not running!"); }
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   return (long)td->thread;
 #elif defined(_WIN32)
   return (long)td->id;
@@ -135,7 +135,7 @@ var Thread_Lt(var self, var obj) {
 
 local bool tls_key_created = false;
 
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
 
 local pthread_key_t key_thread_wrapper;
 local void tls_key_create(void) {
@@ -218,7 +218,7 @@ local ThreadData main_thread_wrapper = { is_main: true, exc_depth: -1 };
 
 var Thread_Current(void) {
   
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   var wrapper = pthread_getspecific(key_thread_wrapper);
 #elif defined(_WIN32)
   var wrapper = TlsGetValue(key_thread_wrapper);
@@ -336,7 +336,7 @@ void Mutex_Lock(var self) {
 
 var Mutex_Lock_Try(var self) {
   MutexData* md = cast(self, Mutex);
-#if defined(__unix__)
+#if defined(__unix__) || defined(__APPLE__)
   int err = pthread_mutex_trylock(&md->mutex);
   if (err == EBUSY) { return False; }
   if (err is EINVAL) { throw(ValueError, "Invalid Argument to Mutex Lock Try"); }


### PR DESCRIPTION
I'm running OS X 10.8.4 with the up to date developer tools:

``` bash
gcc -v
Using built-in specs.
Target: i686-apple-darwin11
Configured with: /private/var/tmp/llvmgcc42/llvmgcc42-2336.11~182/src/configure --disable-checking --enable-werror --prefix=/Applications/Xcode.app/Contents/Developer/usr/llvm-gcc-4.2 --mandir=/share/man --enable-languages=c,objc,c++,obj-c++ --program-prefix=llvm- --program-transform-name=/^[cg][^.-]*$/s/$/-4.2/ --with-slibdir=/usr/lib --build=i686-apple-darwin11 --enable-llvm=/private/var/tmp/llvmgcc42/llvmgcc42-2336.11~182/dst-llvmCore/Developer/usr/local --program-prefix=i686-apple-darwin11- --host=x86_64-apple-darwin11 --target=i686-apple-darwin11 --with-gxx-include-dir=/usr/include/c++/4.2.1
Thread model: posix
gcc version 4.2.1 (Based on Apple Inc. build 5658) (LLVM build 2336.11.00)
```

I was getting the "Threading Model Not Supported" error because the Unix preprocessor variable (correct term?) `__unix__` was not present on my system. Neither was `_WIN32` obviously. This was preventing a build on my configuration (stated above). I've fixed it by adding checks for `__APPLE__` as well.
