### PR TITLE
added special treatment for nested function for clang

### DIFF
--- a/demos/functions.c
+++ b/demos/functions.c
@@ -44,16 +44,27 @@ int main(int argc, char** argv) {
   lambda_partial(add_partial, add_print, $(Int, 5));
   
   call(add_partial, $(Int, 1));
-  
+
   /*
   ** We can use normal c-functions too.
   ** If they have all argument types as "var".
   ** Then they can be uncurried.
   */
+#ifndef __clang__
+
   var Welcome_Pair(var fst, var snd) {
     print("Hello %s and %s!\n", fst, snd);
     return None;
   }
+  
+#else
+
+  var (^Welcome_Pair)(var, var) = ^ var (var fst, var snd) {
+    print("Hello %s and %s!\n", fst, snd);
+    return None;
+  };
+
+#endif
   
   lambda_uncurry(welcome_uncurried, Welcome_Pair, 2);
   


### PR DESCRIPTION
I changed the definition of the nested function "Welcome_Pair" to make it compile on my Macbook, which runs clang-500.2.79. This is the output of `clang --version` on my site:

```
Apple LLVM version 5.0 (clang-500.2.79) (based on LLVM 3.3svn)
Target: x86_64-apple-darwin13.0.2
Thread model: posix
```

I'm not sure if this change is correct since I'm new to this kind of block syntax, I hope it works.
