### PR TITLE
Merge Darwin/Linux Targets Redux

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,55 +1,57 @@
-CC = gcc
-AR = ar
+CC ?= gcc
+AR ?= ar
 
 VERSION = 1.1.6
 PACKAGE = libCello-$(VERSION)
 
-PREFIX=/usr/local
-DESTDIR=
-INCDIR=${PREFIX}/include
-LIBDIR=${PREFIX}/lib
-I=${DESTDIR}/${INCDIR}
-L=${DESTDIR}/${LIBDIR}
+BINDIR = ${PREFIX}/bin
+INCDIR = ${PREFIX}/include
+LIBDIR = ${PREFIX}/lib
 
-SRC = $(wildcard src/*.c)
-OBJ = $(addprefix obj/,$(notdir $(SRC:.c=.o)))
+SRC := $(wildcard src/*.c)
+OBJ := $(addprefix obj/,$(notdir $(SRC:.c=.o)))
 
-TESTS = $(wildcard tests/*.c)
-TESTS_OBJ = $(addprefix obj/,$(notdir $(TESTS:.c=.o)))
+TESTS := $(wildcard tests/*.c)
+TESTS_OBJ := $(addprefix obj/,$(notdir $(TESTS:.c=.o)))
 
-DEMOS = $(wildcard demos/*.c)
-DEMOS_OBJ = $(addprefix obj/,$(notdir $(DEMOS:.c=.o)))
-DEMOS_EXE = $(DEMOS:.c=)
+DEMOS := $(wildcard demos/*.c)
+DEMOS_OBJ := $(addprefix obj/,$(notdir $(DEMOS:.c=.o)))
+DEMOS_EXE := $(DEMOS:.c=)
 
 CFLAGS = -I ./include -std=gnu99 -Wall -Werror -Wno-unused -O3 -g
 LFLAGS = -shared -g -ggdb
 
-PLATFORM = $(shell uname)
-
-ifeq ($(findstring Linux,$(PLATFORM)),Linux)
-	DYNAMIC = libCello.so
-	STATIC = libCello.a
-	CFLAGS += -fPIC
-	LIBS = -lpthread -ldl -lm
-	INSTALL_LIB = mkdir -p ${L} && cp -f ${STATIC} ${L}/$(STATIC)
-	INSTALL_INC = mkdir -p ${I} && cp -r include/* ${I}
-endif
-
-ifeq ($(findstring Darwin,$(PLATFORM)),Darwin)
-	DYNAMIC = libCello.so
-	STATIC = libCello.a
-	CFLAGS += -fPIC -fblocks
-	LIBS = -lpthread -ldl -lm -lBlocksRuntime
-	INSTALL_LIB = mkdir -p ${L} && cp -f $(STATIC) ${L}/$(STATIC)
-	INSTALL_INC = mkdir -p ${I} && cp -r include/* ${I}
-endif
+PLATFORM := $(shell uname)
+COMPILER := $(shell $(CC) -v 2>&1 )
 
 ifeq ($(findstring MINGW,$(PLATFORM)),MINGW)
+	PREFIX ?= C:/MinGW64/x86_64-w64-mingw32
+
 	DYNAMIC = libCello.dll
 	STATIC = libCello.a
-	LIBS = 
-	INSTALL_LIB = cp $(STATIC) C:/MinGW64/x86_64-w64-mingw32/lib/$(STATIC); cp $(DYNAMIC) C:/MinGW64/x86_64-w64-mingw32/bin/$(DYNAMIC)
-	INSTALL_INC = cp -r include/* C:/MinGW64/x86_64-w64-mingw32/include/
+	LIBS =
+
+	INSTALL_LIB = cp $(STATIC) $(LIBDIR)/$(STATIC); cp $(DYNAMIC) $(BINDIR)/$(DYNAMIC)
+	INSTALL_INC = cp -r include/* $(INCDIR)
+else
+	PREFIX ?= /usr/local
+
+	DYNAMIC = libCello.so
+	STATIC = libCello.a
+	LIBS = -lpthread -ldl -lm
+
+	CFLAGS += -fPIC
+
+	INSTALL_LIB = mkdir -p ${LIBDIR} && cp -f ${STATIC} ${LIBDIR}/$(STATIC)
+	INSTALL_INC = mkdir -p ${INCDIR} && cp -r include/* ${INCDIR}
+endif
+
+ifeq ($(findstring clang,$(COMPILER)),clang)
+	CFLAGS += -fblocks
+
+	ifneq ($(findstring Darwin,$(PLATFORM)),Darwin)
+		LIBS += -lBlocksRuntime
+	endif
 endif
 
 # Libraries
@@ -64,7 +66,7 @@ $(STATIC): $(OBJ)
 
 obj/%.o: src/%.c | obj
 	$(CC) $< -c $(CFLAGS) -o $@
-  
+
 obj:
 	mkdir -p obj
 
@@ -73,7 +75,7 @@ obj:
 check: $(TESTS_OBJ) $(STATIC)
 	$(CC) $(TESTS_OBJ) $(STATIC) $(LIBS) -o test
 	./test
-  
+
 obj/%.o: tests/%.c | obj
 	$(CC) $< -c $(CFLAGS) -o $@
 
@@ -89,18 +91,18 @@ demos/%: demos/%.c $(STATIC) | obj
 dist: all | $(PACKAGE)
 	cp -R demos include src tests INSTALL.md LICENSE.md Makefile README.md $(PACKAGE)
 	tar -czf $(PACKAGE).tar.gz $(PACKAGE)
- 
+
 $(PACKAGE):
 	mkdir -p $(PACKAGE)
- 
+
 # Clean
-  
+
 clean:
 	rm -f $(OBJ) $(TESTS_OBJ) $(DEMOS_OBJ) $(STATIC) $(DYNAMIC)
 	rm -f test
-  
+
 # Install
-  
+
 install: all
 	$(INSTALL_LIB)
 	$(INSTALL_INC)


### PR DESCRIPTION
- Add support for customizing CC/AR/PREFIX.
- Clean up hardcoded paths and weird I/L stuff.
- Merge darwin and linux platforms with clang fixes based on push from @igalic #66 with fix for darwin compilation.

This is a proposed fix for issue #70.
