### PR TITLE
Newline after show()

### DIFF
--- a/src/Format.c
+++ b/src/Format.c
@@ -40,7 +40,7 @@ int show(var self) {
 int show_to(var self, var out, int pos) {
   
   if (not type_implements(type_of(self), Show)) {
-    return print_to(out, 0, "<'%s' At 0x%p\n>", type_of(self), self);
+    return print_to(out, 0, "<'%s' At 0x%p>\n", type_of(self), self);
   } else {
     Show* ishow = type_class(type_of(self), Show);
     return ishow->show(self, out, pos);


### PR DESCRIPTION
It was really annoying not having a new line print in this program:

var x = new(Array, Int);
push(x, $(Int, 32));
push(x, $(Int, 6));

/\* <'Array' At 0x0000000000414603 [32, 6]> */
show(x);
delete(x);
