### PR TITLE
added biicode support, tested MinGW, Ubuntu, Mac

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,24 @@
+IF(MSVC)
+	MESSAGE(FATAL_ERROR "Libcello not supported in Visual")
+ENDIF()
+
+INIT_BIICODE_BLOCK()
+
+# Make sure that the test source file are not in the library
+LIST(REMOVE_ITEM BII_LIB_SRC tests/ptest.c tests/ptest.h)
+SET(BII_tests_test_SRC ${BII_tests_test_SRC} 	tests/ptest.c
+												tests/ptest.h
+												tests/core.c
+												tests/data.c
+												tests/functional.c
+												tests/memory.c
+												tests/exceptions.c
+												tests/threading.c)
+ADD_BIICODE_TARGETS()
+
+# Extra configuration
+TARGET_COMPILE_OPTIONS(${BII_BLOCK_TARGET} INTERFACE "-std=gnu99")
+set_source_files_properties(${CMAKE_CURRENT_BINARY_DIR}/cmake_dummy.cpp PROPERTIES COMPILE_FLAGS -std=c++03)
+IF(UNIX)
+	TARGET_LINK_LIBRARIES(${BII_BLOCK_TARGET} INTERFACE -lpthread -ldl -lm)
+ENDIF()

--- a/biicode.conf
+++ b/biicode.conf
@@ -1,0 +1,5 @@
+[parent]
+	diego/libcello: 1
+
+[paths]
+    include


### PR DESCRIPTION
Hi Daniel,

This PR gives support for biicode deps manager. It is totally non-intrusive, just to add 2 files.
It is tested in Win with MinGW, Ubuntu gcc 4.8 and Mac CLang 5.1

I have already published a copy to biicode, ready to use: http://www.biicode.com/diego/libcello
There is an example how to use it with biicode in: http://www.biicode.com/diego/cello_examples

I would be happy to assist in case you want to publish your own copy to biicode, it is very simple.

Also, I would love to contribute adding continuous integration with TravisCI (free), so after every push, tests are run.
