### PR TITLE
ADD: MSVC support by protecting stdlib.h include in ptest.c

### DIFF
--- a/tests/ptest.c
+++ b/tests/ptest.c
@@ -4,7 +4,9 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <time.h>
-#include <unistd.h>
+#if defined(CELLO_UNIX)
+# include <unistd.h>
+#endif
 
 /* Globals */
 


### PR DESCRIPTION
Hello,

Just protect the include of stdlib.h with CELLO_UNIX macro to get support for Windows.

Thanks a lot for this library

Bertrand