### PR TITLE
Benchmarks: improve make gc_lua.lua

### DIFF
--- a/benchmarks/GC/gc_lua.lua
+++ b/benchmarks/GC/gc_lua.lua
@@ -1,6 +1,6 @@
 
 function Int () 
-  return {val=0}
+  return {}
 end
 
 function create_objects(depth)

--- a/benchmarks/GC/gc_lua.lua
+++ b/benchmarks/GC/gc_lua.lua
@@ -17,12 +17,12 @@ function create_objects(depth)
         return;
     end
   
-    for i=0,10 do
+    for i = 1, 10 do
       create_objects(depth+1)
     end
 end
 
-for i=0, 10000 do
+for i = 1, 10000 do
     create_objects(0)
 end
 


### PR DESCRIPTION
We're benchmarking the GC overhead here but having `{val=0}` rather than `{}` triggers the hashing of `"val"` and doubles the work of the GC which must scan each `ixx.val`.

On my machine, this halves the Lua time (from 21s to 11s), and gets LuaJIT down from 1.63s  to ~1s.

The same logic applies probably to `gc_javascript.js` as well.

As a side note, Lua and LuaJIT use the same GC but the results differ by a large amount, which means that you're still not measuring what you think you're measuring. The LuaJIT compiler may be smart enough to skip the allocations.

Please don't merge this at once, there may be more tweaks coming.
