### PR TITLE
Fix fault in incremental build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,7 +121,7 @@ $(DYNAMIC): $(OBJ)
 $(STATIC): $(OBJ)
 	$(AR) rcs $@ $(OBJ)
 
-obj/%.o: src/%.c | obj
+obj/%.o: src/%.c include/Cello.h | obj
 	$(CC) $< -c $(CFLAGS) -o $@
 
 obj:


### PR DESCRIPTION
Hello

This pull request adds a missing Make dependency.
In particular, object files depend on the header `include/Cello.h`. So they must be regenerated whenever there are updates to this header.